### PR TITLE
Stop propagating Backspace event

### DIFF
--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -180,6 +180,7 @@ export default Component.extend({
             this.attrs.onRemove(last);
           }
 
+          e.preventDefault();
           break;
         }
 

--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -178,9 +178,9 @@ export default Component.extend({
           if (isPresent(values) && this.get('token') === '') {
             let last = this.getElement(values, get(values, 'length') - 1);
             this.attrs.onRemove(last);
+            e.preventDefault();
           }
 
-          e.preventDefault();
           break;
         }
 


### PR DESCRIPTION
Some browsers use Backspace to navigate back in history. This can also happen when removing items with ember-select.