### PR TITLE
Don't Select if you can't Search

### DIFF
--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -159,7 +159,7 @@ export default Component.extend({
         input.focus();
       }
 
-      if (input && !this.get('isFocus')) {
+      if (input && !this.get('isFocus') && this.get('canSearch')) {
         // Select text (similar to TAB)
         input.select();
       }


### PR DESCRIPTION
Since you can't type, it doesn't make sense to select the text.