### PR TITLE
Updates to keyboard events

### DIFF
--- a/addon/components/select-dropdown.js
+++ b/addon/components/select-dropdown.js
@@ -156,9 +156,8 @@ export default Component.extend({
   tabEnterKeys(selected) {
     if (selected && this.get('options').includes(selected)) {
       this.send('select', selected);
-    } else {
-      let token = this.get('freeText') ? this.get('token') : '';
-      this.attrs.select(token);
+    } else if (this.get('freeText')) {
+      this.attrs.select(this.get('token'));
     }
   },
 

--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -194,7 +194,11 @@ export default Component.extend({
 
           break;
         case 27: // ESC
-          this.send('clear');
+          if (this.get('canSearch') && this.get('hasInput')) {
+            this.send('clear');
+          } else {
+            this.set('isOpen', false);
+          }
           break;
         case 38: // Up Arrow
         case 40: // Down Arrow


### PR DESCRIPTION
Right now, if you simply click on the dropdown and press Enter, your input will be cleared regardless of whether or not empty is a valid input. Pressing Escape also clears unconditionally.

These two commits fix the aforementioned problems.