### PR TITLE
Tab/Enter fix for dropdown groups

### DIFF
--- a/addon/components/select-dropdown.js
+++ b/addon/components/select-dropdown.js
@@ -154,7 +154,7 @@ export default Component.extend({
   },
 
   tabEnterKeys(selected) {
-    if (selected && this.get('options').includes(selected)) {
+    if (selected && this.get('list').includes(selected)) {
       this.send('select', selected);
     } else if (this.get('freeText')) {
       this.attrs.select(this.get('token'));

--- a/addon/components/select-dropdown.js
+++ b/addon/components/select-dropdown.js
@@ -11,7 +11,6 @@ const {
   isEmpty,
   isNone,
   isPresent,
-  on,
   run
 } = Ember;
 


### PR DESCRIPTION
When the user presses Tab or Enter, we check that what was entered is in the list of options. However, in the case of grouped dropdowns, said list was only the top-level nodes (the group headers).

This fixes that so all nodes are included, and now Enter and Tab work on grouped dropdowns.