### PR TITLE
Always Clear Placeholder for IE

### DIFF
--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -75,7 +75,9 @@ export default Component.extend({
     if (!this.canSearch) {
       this.set('openOnFocus', true);
     }
+  },
 
+  didReceiveAttrs() {
     /* IE10+ Triggers an input event when focus changes on
      * an input element if the element has a placeholder.
      * https://connect.microsoft.com/IE/feedback/details/810538/

--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -78,6 +78,8 @@ export default Component.extend({
   },
 
   didReceiveAttrs() {
+    this._super(...arguments);
+
     /* IE10+ Triggers an input event when focus changes on
      * an input element if the element has a placeholder.
      * https://connect.microsoft.com/IE/feedback/details/810538/


### PR DESCRIPTION
For working around the IE placeholder bug:

Previously, the placeholder was only cleared on `init`. When your model loads, the placeholder is brought back (somehow). If you modify the model again, the placeholder is there and so IE will fire off an event when it's not supposed to. Basically, if you have `openOnFocus=true`, IE will open the select menu if you ever try to change the model.

With this change, the placeholder will always be cleared on IE. This will fix the select box opening itself up.