### PR TITLE
Fix Component Lifecycle Deprecations

### DIFF
--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -98,7 +98,7 @@ export default Component.extend({
     }
   },
 
-  didUpdateAttrs(attrs) {
+  didUpdateAttrs() {
     this._super(...arguments);
 
     // Need to open on lazy models
@@ -107,8 +107,8 @@ export default Component.extend({
     }
 
     // Update input if value has changed
-    let newValue = attrs.newAttrs.value;
-    let oldValue = attrs.oldAttrs.value;
+    let newValue = this.get('value');
+    let oldValue = this.get('_oldValue');
     if (oldValue && newValue && oldValue.value !== newValue.value) {
       let { label } = this.retrieveOption(newValue.value);
       if (label !== this.get('token')) {


### PR DESCRIPTION
Deprecations were being thrown by Ember for this change:
https://emberjs.com/deprecations/v2.x/#toc_arguments-in-component-lifecycle-hooks

Fixes issue #9 

There was a previous issue with removing old value ( #7  )  but I'm not sure if that still needs to change.