### PR TITLE
Fix lists of primitives

### DIFF
--- a/addon/components/select-dropdown.js
+++ b/addon/components/select-dropdown.js
@@ -50,7 +50,7 @@ export default Component.extend({
     },
 
     select(node) {
-      this.attrs.select(node.content, true);
+      this.attrs.select(node.content || node.id, true);
     }
   },
 

--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -2,7 +2,6 @@ import { and, bool, not, notEmpty, or } from '@ember/object/computed';
 import Component from '@ember/component';
 import { computed, get } from '@ember/object';
 import Evented from '@ember/object/evented';
-import { inject as service } from '@ember/service';
 import { isPresent, isBlank } from '@ember/utils';
 import { run } from '@ember/runloop';
 import layout from '../templates/components/x-select';

--- a/addon/utils/tree.js
+++ b/addon/utils/tree.js
@@ -70,7 +70,6 @@ export function buildTree(model, options) {
 // Builds a list of proxies from a model of values
 export function buildFlatList(model) {
   let list = model.map(node => ObjectProxy.create({
-    content: node,
     id: node,
     name: node,
     isSelected: false,


### PR DESCRIPTION
In its internals, `isPresent()` looks for a `.length` property on the passed ObjectProxy. This causes Ember to die if the `content` property is a primitive. Probably introduced in 3.0 since the message is about direct access instead of `.get()`.

This change makes it no longer set `content` for non-objects.