### PR TITLE
IE: don't trigger change() upon blur in Ember 3

### DIFF
--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -128,7 +128,7 @@ export default Component.extend(Evented, {
        */
       if (document.documentMode) {
         let isDirty = this.get('isDirty');
-        let oldValue = this.get('oldValue');
+        let oldValue = this.get('oldValue') || '';
         if (!isDirty && oldValue === query) {
           return;
         }


### PR DESCRIPTION
`change()` was being fired whenever the user left an empty `x-select`