### PR TITLE
Ember.js 4 Fixes

### DIFF
--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -7,8 +7,6 @@ import { isPresent, isBlank } from '@ember/utils';
 
 import layout from '../templates/components/x-select';
 
-const isEdgeIe = typeof StyleMedia !== 'undefined';
-
 export default Component.extend(Evented, {
   layout,
   classNames: ['ember-select'],
@@ -127,18 +125,6 @@ export default Component.extend(Evented, {
     },
 
     change(query) {
-      /* IE10+ Triggers an input event when focus changes on
-       * an input element if the element has a placeholder.
-       * https://connect.microsoft.com/IE/feedback/details/810538/
-       */
-      if (document.documentMode) {
-        let isDirty = this.get('isDirty');
-        let oldValue = this.get('oldValue') || '';
-        if (!isDirty && oldValue === query) {
-          return;
-        }
-      }
-
       this.setProperties({
         isDirty: true,
         token: query
@@ -257,9 +243,8 @@ export default Component.extend(Evented, {
       this.set('isDirty', false);
       this.setOption(option, selected, notify);
 
-      /* Blur on selection when single
-       * IE & Edge do not run the events in proper order */
-      if (!this.get('multiple') && !isEdgeIe) {
+      // Blur on selection when single
+      if (!this.get('multiple')) {
         this.get('input').blur();
       }
     }

--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -46,9 +46,9 @@ export default Component.extend(Evented, {
   multiple: bool('values'),
   shouldFilter: or('isDirty', 'multiple', 'hasChanged'),
 
-  input: computed(function() {
+  get input() {
     return document.querySelector(`#${this.elementId} input`);
-  }),
+  },
 
   hasChanged: computed('token', 'value', function() {
     let token = this.get('token');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-select",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Select component",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
- Use `get` to avoid cached `computed`
- Remove IE & Edge (legacy) workarounds