### PR TITLE
Ember 6 Compat: Remove "action", Change to Class Style

### DIFF
--- a/addon/components/select-dropdown-group.js
+++ b/addon/components/select-dropdown-group.js
@@ -1,32 +1,33 @@
 import { computed, get } from '@ember/object';
 import { isPresent } from '@ember/utils';
 
-import SelectDropdown from './select-dropdown';
+import SelectDropdownComponent from './select-dropdown';
 import layout from '../templates/components/select-dropdown-group';
 import { getDescendents } from '../utils/tree';
 
-export default SelectDropdown.extend({
-  layout,
-  groups: null,
-  list: null,
+export default class SelectDropdownGroupComponent extends SelectDropdownComponent {
+  layout = layout;
+  groups = null;
+  list = null;
 
   didReceiveAttrs() {
-    this._super(...arguments);
+    super.didReceiveAttrs(...arguments);
 
     // Tree built in extended component
     let groups = this.get('list');
     let list = getDescendents(groups);
 
     this.setProperties({ list, groups });
-  },
+  }
 
-  options: computed('token', 'model.[]', 'values.[]', function() {
+  @computed('token', 'model.[]', 'values.[]')
+  get options() {
     if (this.get('shouldFilter')) {
       this.filterModel();
     }
 
     return this.get('groups');
-  }),
+  }
 
   setVisibility(list, token) {
     list
@@ -41,7 +42,7 @@ export default SelectDropdown.extend({
           .shift()
           .set('isVisible', true);
       });
-  },
+  }
 
   upDownKeys(selected, event) {
     let list = this.get('list')
@@ -50,4 +51,4 @@ export default SelectDropdown.extend({
 
     this.move(list, selected, event.keyCode);
   }
-});
+}

--- a/addon/components/select-dropdown-option.js
+++ b/addon/components/select-dropdown-option.js
@@ -1,32 +1,9 @@
 import Component from '@ember/component';
-import { bind } from '@ember/runloop';
 
 import layout from '../templates/components/select-dropdown-option';
 
-export default Component.extend({
-  layout,
-  classNames: ['es-option'],
-  classNameBindings: ['model.isSelected:es-highlight'],
-
-  init() {
-    this._super(...arguments);
-
-    this.set('handleMouseEnter', bind(this, () => this.hover(this.model)));
-  },
-
-  didInsertElement() {
-    this._super(...arguments);
-
-    this.element.addEventListener('mouseenter', this.handleMouseEnter);
-  },
-
-  willDestroyElement() {
-    this._super(...arguments);
-
-    this.element.removeEventListener('mouseenter', this.handleMouseEnter);
-  },
-
-  click() {
-    this.select(this.model);
-  }
-});
+export default class SelectDropdownOptionComponent extends Component {
+  layout = layout;
+  classNames = ['es-option'];
+  classNameBindings = ['model.isSelected:es-highlight'];
+}

--- a/addon/components/select-dropdown.js
+++ b/addon/components/select-dropdown.js
@@ -1,23 +1,24 @@
 import Component from '@ember/component';
 import { computed, get } from '@ember/object';
 import { next } from '@ember/runloop';
+import { action } from '@ember/object';
 import { isEmpty, isNone, isPresent } from '@ember/utils';
 
 import layout from '../templates/components/select-dropdown';
 import { buildTree } from '../utils/tree';
 import { bringInView } from '../utils/view';
 
-export default Component.extend({
-  layout,
-  list: null,
+export default class SelectDropdownComponent extends Component {
+  layout = layout;
+  list = null;
 
   didInsertElement() {
-    this._super(...arguments);
+    super.didInsertElement(...arguments);
     this.parent.on('keyPress', this, this.keys);
-  },
+  }
 
   didReceiveAttrs() {
-    this._super(...arguments);
+    super.didReceiveAttrs(...arguments);
 
     let options = this.getProperties('valueKey', 'labelKey');
     let model = this.get('model');
@@ -25,36 +26,37 @@ export default Component.extend({
 
     this.set('list', list);
     this.filterModel();
-  },
+  }
 
   willDestroyElement() {
-    this._super(...arguments);
+    super.willDestroyElement(...arguments);
     this.parent.off('keyPress', this, this.keys);
-  },
+  }
 
-  options: computed('token', 'model.[]', 'values.[]', function() {
+  @computed('token', 'model.[]', 'values.[]')
+  get options() {
     if (this.get('shouldFilter')) {
       this.filterModel();
     }
 
     return this.get('list');
-  }),
+  }
 
-  actions: {
-    hover(node) {
-      let selected = this.get('selected');
-      if (selected) {
-        selected.set('isSelected', false);
-      }
-
-      this.set('selected', node);
-      node.set('isSelected', true);
-    },
-
-    select(node) {
-      this.select(node.content || node.id, true);
+  @action
+  hover(node) {
+    let selected = this.get('selected');
+    if (selected) {
+      selected.set('isSelected', false);
     }
-  },
+
+    this.set('selected', node);
+    node.set('isSelected', true);
+  }
+
+  @action
+  select(node) {
+    this.attrs.parent.select(node.content || node.id, true);
+  }
 
   /* Filter out existing selections. Mark everything
    visible if no search, otherwise update visiblity. */
@@ -82,7 +84,7 @@ export default Component.extend({
       firstVisible.set('isSelected', true);
       this.set('selected', firstVisible);
     }
-  },
+  }
 
   keys(event) {
     let selected = this.get('selected');
@@ -98,12 +100,12 @@ export default Component.extend({
         this.upDownKeys(selected, event);
         break;
     }
-  },
+  }
 
   // Prevent event bubbling up
   mouseDown(event) {
     event.preventDefault();
-  },
+  }
 
   // Down: 40, Up: 38
   move(list, selected, direction) {
@@ -140,24 +142,24 @@ export default Component.extend({
     node.set('isSelected', true);
 
     next(this, bringInView, '.es-options', '.es-highlight');
-  },
+  }
 
   setVisibility(list, token) {
     list
       .filter(el => get(el, 'name').toString().toLowerCase().indexOf(token) > -1)
       .forEach(el => el.set('isVisible', true));
-  },
+  }
 
   tabEnterKeys(selected) {
     if (selected && this.get('list').includes(selected)) {
-      this.send('select', selected);
+      this.select(selected);
     } else if (this.get('freeText')) {
       this.select(this.get('token'));
     }
-  },
+  }
 
   upDownKeys(selected, event) {
     let list = this.get('list').filterBy('isVisible');
     this.move(list, selected, event.keyCode);
   }
-});
+}

--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -1,54 +1,56 @@
 import Component from '@ember/component';
 import { computed, get } from '@ember/object';
 import { and, bool, not, notEmpty, or } from '@ember/object/computed';
-import Evented from '@ember/object/evented';
 import { next } from '@ember/runloop';
+import { action } from '@ember/object';
+import Evented from '@ember/object/evented';
 import { isPresent, isBlank } from '@ember/utils';
-
 import layout from '../templates/components/x-select';
 
-export default Component.extend(Evented, {
-  layout,
-  classNames: ['ember-select'],
-  classNameBindings: [
+export default class XSelectComponent extends Component.extend(Evented) {
+  layout = layout;
+  classNames = ['ember-select'];
+  classNameBindings = [
     'isOpen:es-open', 'isFocus:es-focus',
     'canSearch::es-select', 'multiple:es-multiple'
-  ],
+  ];
 
-  autofocus: false,
-  canSearch: true,
-  disabled: false,
-  dropdown: 'select-dropdown',
-  freeText: false,
-  isDirty: false,
-  isFocus: false,
-  isOpen: false,
-  openOnFocus: false,
-  placeholder: 'Type...',
-  required: false,
-  token: '',
-  value: '',
+  autofocus = false;
+  canSearch = true;
+  disabled = false;
+  dropdown = 'select-dropdown';
+  freeText = false;
+  isDirty = false;
+  isFocus = false;
+  isOpen = false;
+  openOnFocus = false;
+  placeholder = 'Type...';
+  required = false;
+  token = '';
+  value = '';
 
-  labelKey: 'label',
-  valueKey: 'value',
+  labelKey = 'label';
+  valueKey = 'value';
 
-  canClear: and('enabled', 'canSearch', 'hasOptions'),
-  canOpen: or('hasInput', 'openOnFocus'),
-  enabled: not('disabled'),
-  hasDropdown: and('enabled', 'hasModel'),
-  hasInput: notEmpty('token'),
-  hasModel: notEmpty('model'),
-  hasOptions: or('hasInput', 'hasValue', 'hasValues'),
-  hasValue: notEmpty('value'),
-  hasValues: notEmpty('values'),
-  multiple: bool('values'),
-  shouldFilter: or('isDirty', 'multiple', 'hasChanged'),
+  @and('enabled', 'canSearch', 'hasOptions') canClear;
+  @or('hasInput', 'openOnFocus') canOpen;
+  @not('disabled') enabled;
+  @and('enabled', 'hasModel') hasDropdown;
+  @notEmpty('token') hasInput;
+  @notEmpty('model') hasModel;
+  @or('hasInput', 'hasValue', 'hasValues') hasOptions;
+  @notEmpty('value') hasValue;
+  @notEmpty('values') hasValues;
+  @bool('values') multiple;
+
+  @or('isDirty', 'multiple', 'hasChanged') shouldFilter;
 
   get input() {
     return document.querySelector(`#${this.elementId} input`);
-  },
+  }
 
-  hasChanged: computed('token', 'value', function() {
+  @computed('token', 'value')
+  get hasChanged() {
     let token = this.get('token');
     let option = this.get('value');
 
@@ -56,10 +58,10 @@ export default Component.extend(Evented, {
       let { label } = this.retrieveOption(option);
       return token !== label;
     }
-  }),
+  };
 
   init() {
-    this._super(...arguments);
+    super.init(...arguments);
 
     if (this.disabled) {
       this.set('canSearch', false);
@@ -70,19 +72,19 @@ export default Component.extend(Evented, {
     }
 
     this.set('oldValue', this.get('value'));
-  },
+  }
 
   didInsertElement() {
-    this._super(...arguments);
+    super.didInsertElement(...arguments);
 
     let value = this.get('value');
     if (isPresent(value)) {
       next(this, () => this.setOption(value));
     }
-  },
+  }
 
   didUpdateAttrs() {
-    this._super(...arguments);
+    super.didUpdateAttrs(...arguments);
 
     // Need to open on lazy models
     if (this.isDirty) {
@@ -97,173 +99,178 @@ export default Component.extend(Evented, {
       this.set('oldLabel', label);
       this.set('oldValue', value);
     }
-  },
+  }
 
-  actions: {
-    blur() {
-      // IE bug: prevent closing dropdown on scrollbar click
-      if (document.activeElement.classList.contains('es-options')) {
-        return;
-      }
+  @action
+  blur() {
+    if (this.get('isDirty')) {
+      // Clear unallowed input in strict single mode
+      let option = this.get('freeText') ? this.get('token') : '';
 
-      if (this.get('isDirty')) {
-        // Clear unallowed input in strict single mode
-        let option = this.get('freeText') ? this.get('token') : '';
-
-        this.set('isDirty', false);
-        this.setOption(option, false, !this.get('multiple'));
-      }
-
-      this.setProperties({
-        isFocus: false,
-        isOpen: false
-      });
-
-      if (this.onBlur) {
-        this.onBlur();
-      }
-    },
-
-    change(query) {
-      this.setProperties({
-        isDirty: true,
-        token: query
-      });
-
-      if (this.onChange) {
-        this.onChange(query);
-      }
-
-      if (isPresent(query)) {
-        this.open();
-      }
-    },
-
-    clear() {
       this.set('isDirty', false);
-      this.setOption('', false, !this.get('multiple'));
+      this.setOption(option, false, !this.get('multiple'));
+    }
 
-      if (this.onClear) {
-        this.onClear();
-      }
+    this.setProperties({
+      isFocus: false,
+      isOpen: false
+    });
 
-      this.send('focus');
-    },
+    if (this.onBlur) {
+      this.onBlur();
+    }
+  }
 
-    dropdown() {
-      let isOpen = this.toggleProperty('isOpen');
-      if (isOpen) {
-        this.get('input').focus();
-      }
-    },
+  @action
+  clear() {
+    this.set('isDirty', false);
+    this.setOption('', false, !this.get('multiple'));
 
-    focus() {
-      if (this.get('disabled')) {
-        return this.send('blur');
-      }
+    if (this.onClear) {
+      this.onClear();
+    }
 
-      let input = this.get('input');
-      if (input) {
-        input.focus();
-      }
+    this.focus();
+  }
 
-      if (input && !this.get('isFocus') && this.get('canSearch')) {
-        // Select text (similar to TAB)
-        input.select();
-      }
+  @action
+  focus() {
+    if (this.get('disabled')) {
+      return this.blur();
+    }
 
-      if (!this.get('isOpen')) {
-        this.open();
-      }
-    },
+    let input = this.get('input');
+    if (input) {
+      input.focus();
+    }
 
-    keypress(e) {
-      let isOpen = this.get('isOpen');
+    if (input && !this.get('isFocus') && this.get('canSearch')) {
+      // Select text (similar to TAB)
+      input.select();
+    }
 
-      switch (e.keyCode) {
-        case 8: { // Backspace
-          let values = this.get('values');
-          if (isPresent(values) && this.get('token') === '') {
-            let last = this.getElement(values, get(values, 'length') - 1);
-            this.onRemove(last);
-            e.preventDefault();
-          }
+    if (!this.get('isOpen')) {
+      this.open();
+    }
+  }
 
-          break;
+  @action
+  keypress(e) {
+    let isOpen = this.get('isOpen');
+
+    switch (e.keyCode) {
+      case 8: { // Backspace
+        let values = this.get('values');
+        if (isPresent(values) && this.get('token') === '') {
+          let last = this.getElement(values, get(values, 'length') - 1);
+          this.onRemove(last);
+          e.preventDefault();
         }
 
-        case 9: // TAB
-        case 13: // Enter
-          if (isOpen) {
-            this.trigger('keyPress', e);
-          } else if (this.get('freeText')) {
-            this.send('select', this.get('token'), false);
-          }
-
-          break;
-        case 27: // ESC
-          if (this.get('canSearch') && this.get('hasInput')) {
-            this.send('clear');
-          } else {
-            this.set('isOpen', false);
-          }
-          break;
-        case 38: // Up Arrow
-        case 40: // Down Arrow
-          if (isOpen) {
-            this.trigger('keyPress', e);
-          } else {
-            this.set('isOpen', true);
-          }
-
-          e.preventDefault();
-          break;
-      }
-    },
-
-    remove(selection) {
-      this.onRemove(selection);
-      this.send('focus');
-    },
-
-    select(option, selected) {
-      let isNew = !selected && this.get('freeText') && this.get('isDirty');
-      let allowNew = isPresent(this.onCreate);
-      let valid = isPresent(option);
-
-      /* Notify when option is either
-       *  - selected
-       *  - new, empty and cannot be created */
-      let notify = selected || isNew && !allowNew;
-
-      if (allowNew && valid && isNew) {
-        this.onCreate(option);
+        break;
       }
 
-      this.set('isDirty', false);
-      this.setOption(option, selected, notify);
+      case 9: // TAB
+      case 13: // Enter
+        if (isOpen) {
+          this.trigger('keyPress', e);
+        } else if (this.get('freeText')) {
+          this.select(this.get('token'), false);
+        }
 
-      // Blur on selection when single
-      if (!this.get('multiple')) {
-        this.get('input').blur();
-      }
+        break;
+      case 27: // ESC
+        if (this.get('canSearch') && this.get('hasInput')) {
+          this.clear();
+        } else {
+          this.set('isOpen', false);
+        }
+        break;
+      case 38: // Up Arrow
+      case 40: // Down Arrow
+        if (isOpen) {
+          this.trigger('keyPress', e);
+        } else {
+          this.set('isOpen', true);
+        }
+
+        e.preventDefault();
+        break;
+      default:
+        // `onkeydown` is triggered before input value is updated, so we must figure it out ourselves
+        let query = this.input.value;
+
+        // Only append new character if it's printable
+        if (e.key.length === 1) {
+          query += e.key;
+        }
+
+        this.setProperties({
+          isDirty: true,
+          token: query
+        });
+
+        if (this.onChange) {
+            this.onChange(query);
+        }
+
+        if (isPresent(query)) {
+            this.open();
+        }
     }
-  },
+  }
 
-  // Handle plain arrays and Ember Data relationships
+  @action
+  remove(selection) {
+    this.onRemove(selection);
+    this.focus();
+  }
+
+  @action
+  select(option, selected) {
+    let isNew = !selected && this.get('freeText') && this.get('isDirty');
+    let allowNew = isPresent(this.onCreate);
+    let valid = isPresent(option);
+
+    /* Notify when option is either
+     *  - selected
+     *  - new, empty and cannot be created */
+    let notify = selected || isNew && !allowNew;
+
+    if (allowNew && valid && isNew) {
+      this.onCreate(option);
+    }
+
+    this.set('isDirty', false);
+    this.setOption(option, selected, notify);
+
+    // Blur on selection when single
+    if (!this.get('multiple')) {
+      this.get('input').blur();
+    }
+  }
+
+  @action
+  showDropdown(event) {
+    let isOpen = this.toggleProperty('isOpen');
+    if (isOpen) {
+      this.get('input').focus();
+    }
+
+    event.stopPropagation();
+  }
+
   getElement(model, position) {
     return model[position] || model.objectAt(position);
-  },
+  }
 
   open() {
     this.setProperties({
       isOpen: this.get('hasDropdown') && this.get('canOpen'),
       isFocus: true
     });
-  },
+  }
 
-  /* Retrieve `option`, `value` and `label` given a selection
-   * which can be either an option (object) or a value */
   retrieveOption(option) {
     let model = this.get('model');
     let label = option;
@@ -284,7 +291,7 @@ export default Component.extend(Evented, {
     }
 
     return { option, value, label };
-  },
+  }
 
   setOption(selection, selected, notify) {
     let { option, value, label = '' } = this.retrieveOption(selection);
@@ -314,4 +321,4 @@ export default Component.extend(Evented, {
       this.set('isOpen', false);
     }
   }
-});
+}

--- a/addon/templates/components/select-dropdown-group.hbs
+++ b/addon/templates/components/select-dropdown-group.hbs
@@ -3,11 +3,11 @@
     <div class="es-group">{{group.name}}</div>
     {{#each group.children as |option|}}
       {{#if option.isVisible}}
-        {{select-dropdown-option
+        <SelectDropdownOption
           model=option
-          select=(action "select")
-          hover=(action "hover")
-        }}
+          select={{@select}}
+          hover={{@hover}}
+        />
       {{/if}}
     {{/each}}
   {{/if}}

--- a/addon/templates/components/select-dropdown.hbs
+++ b/addon/templates/components/select-dropdown.hbs
@@ -1,9 +1,9 @@
 {{#each this.options as |option|}}
   {{#if option.isVisible}}
-    {{select-dropdown-option
-      model=option
-      select=(action "select")
-      hover=(action "hover")
-    }}
+    <SelectDropdownOption
+      @model={{option}}
+      {{on "click" (fn this.select option)}}
+	  {{on "mouseenter" (fn this.hover option)}}
+    />
   {{/if}}
 {{/each}}

--- a/addon/templates/components/x-select.hbs
+++ b/addon/templates/components/x-select.hbs
@@ -1,9 +1,9 @@
-<div class="es-control" {{action "focus" on="mouseDown"}}>
+<div class="es-control" {{on "click" this.focus}}>
   <div class="es-input">
     {{#if this.hasValues}}
       <span class="es-selections">
         {{#each @values as |option|}}
-          <span {{action "remove" option}}>
+          <span {{on "click" (fn this.remove option)}}>
             {{if (get option this.labelKey) (get option this.labelKey) option}} ×
           </span>
         {{/each}}
@@ -16,21 +16,20 @@
       autofocus={{this.autofocus}}
       placeholder={{unless this.hasValues this.placeholder ""}}
       readonly={{unless this.canSearch "readonly"}}
-      oninput={{action "change" value="target.value"}}
-      onkeydown={{action "keypress"}}
-      onfocus={{action "focus"}}
-      onblur={{action "blur"}}
+      onkeydown={{this.keypress}}
+      onfocus={{this.focus}}
+      onblur={{this.blur}}
     >
   </div>
 
   {{#if this.canClear}}
-    <span class="es-clear-zone" title="Clear" aria-label="Clear" {{action "clear"}}>
+    <span class="es-clear-zone" title="Clear" aria-label="Clear" {{on "click" this.clear}}>
       <span class="es-clear">×</span>
     </span>
   {{/if}}
 
   {{#if this.hasDropdown}}
-    <span class="es-arrow-zone" {{action "dropdown" on="mouseDown" bubbles=false}}>
+    <span class="es-arrow-zone" {{on "click" this.showDropdown}}>
       <span class="es-arrow"></span>
     </span>
   {{/if}}
@@ -47,7 +46,6 @@
       valueKey=this.valueKey
       freeText=this.freeText
       shouldFilter=this.shouldFilter
-      select=(action "select")
     }}
   </div>
 {{/if}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-select",
-  "version": "0.8.5",
+  "version": "0.9.0",
   "description": "Select component",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
Ember 6 removes support for "action" helper in templates officially, after a long period of deprecation. https://deprecations.emberjs.com/id/template-action/

This PR does two big things and a few minor things:
1. **Replace all uses of `action` in templates with either direct references or `fn` helper if currying is needed**
2. **Updates JS files to be in class syntax rather than classic syntax**
3. Remove custom `handleMouseEnter` code on `select-dropdown-option`, simplifying code
4. Removes `oninput` binding on the `input` element since there was an issue with the order of events fired. Its functionality was moved into the existing `keypress` handler. This required a minor _workaround_ since the `input` element's `value` is not updated until after the key has been handled, requiring us to concat the current value plus the newly-entered key
5. Remove old IE bug handling in `blur()`
6. Renames `dropdown` handler due to a conflict between the passed-in value (a string, to specify custom dropdown component) and a function
7. Likewise, removes `select` from being passed to the dropdown component due to naming conflicts. Use `parent.select` instead

Basic, functionality appears to be working. I'm opening this as a draft to gather feedback.