### PR TITLE
Use class syntax for dropdown components

### DIFF
--- a/addon/components/select-dropdown-group.js
+++ b/addon/components/select-dropdown-group.js
@@ -1,37 +1,38 @@
 import { computed, get } from '@ember/object';
 import { isPresent } from '@ember/utils';
 
-import SelectDropdown from './select-dropdown';
+import SelectDropdownComponent from './select-dropdown';
 import layout from '../templates/components/select-dropdown-group';
 import { getDescendents } from '../utils/tree';
 
-export default SelectDropdown.extend({
-  layout,
-  groups: null,
-  list: null,
+export default class SelectDropdownGroupComponent extends SelectDropdownComponent {
+  layout = layout;
+  groups = null;
+  list = null;
 
   didReceiveAttrs() {
-    this._super(...arguments);
+    super.didReceiveAttrs(...arguments);
 
     // Tree built in extended component
     let groups = this.get('list');
     let list = getDescendents(groups);
 
     this.setProperties({ list, groups });
-  },
+  }
 
-  options: computed('token', 'model.[]', 'values.[]', function() {
+  @computed('token', 'model.[]', 'values.[]')
+  get options() {
     if (this.get('shouldFilter')) {
       this.filterModel();
     }
 
     return this.get('groups');
-  }),
+  }
 
   setVisibility(list, token) {
     list
       .filter(el => isPresent(get(el, 'parentId')))
-      .filter(el => get(el, 'name').toString().toLowerCase().indexOf(token) > -1)
+      .filter(el => get(el, 'name').toString().toLowerCase().includes(token))
       .forEach(el => {
         el.set('isVisible', true);
 
@@ -41,7 +42,7 @@ export default SelectDropdown.extend({
           .shift()
           .set('isVisible', true);
       });
-  },
+  }
 
   upDownKeys(selected, event) {
     let list = this.get('list')
@@ -50,4 +51,4 @@ export default SelectDropdown.extend({
 
     this.move(list, selected, event.keyCode);
   }
-});
+}

--- a/addon/components/select-dropdown-option.js
+++ b/addon/components/select-dropdown-option.js
@@ -1,32 +1,8 @@
 import Component from '@ember/component';
-import { bind } from '@ember/runloop';
 
 import layout from '../templates/components/select-dropdown-option';
-
-export default Component.extend({
-  layout,
-  classNames: ['es-option'],
-  classNameBindings: ['model.isSelected:es-highlight'],
-
-  init() {
-    this._super(...arguments);
-
-    this.set('handleMouseEnter', bind(this, () => this.hover(this.model)));
-  },
-
-  didInsertElement() {
-    this._super(...arguments);
-
-    this.element.addEventListener('mouseenter', this.handleMouseEnter);
-  },
-
-  willDestroyElement() {
-    this._super(...arguments);
-
-    this.element.removeEventListener('mouseenter', this.handleMouseEnter);
-  },
-
-  click() {
-    this.select(this.model);
-  }
-});
+export default class SelectDropdownOptionComponent extends Component {
+  layout = layout;
+  classNames = ['es-option'];
+  classNameBindings = ['model.isSelected:es-highlight'];
+}

--- a/addon/templates/components/select-dropdown-group.hbs
+++ b/addon/templates/components/select-dropdown-group.hbs
@@ -4,11 +4,11 @@
       <div class="es-group">{{group.name}}</div>
       {{#each group.children as |option|}}
         {{#if option.isVisible}}
-          {{select-dropdown-option
-            model=option
-            select=(action "select")
-            hover=(action "hover")
-          }}
+          <SelectDropdownOption
+            @model={{option}}
+            {{on "click" (fn this.select option)}}
+            {{on "mouseenter" (fn this.hover option)}}
+          />
         {{/if}}
       {{/each}}
     </span>

--- a/addon/templates/components/select-dropdown.hbs
+++ b/addon/templates/components/select-dropdown.hbs
@@ -1,9 +1,9 @@
 {{#each this.options as |option|}}
   {{#if option.isVisible}}
-    {{select-dropdown-option
-      model=option
-      select=(action "select")
-      hover=(action "hover")
-    }}
+    <SelectDropdownOption
+      @model={{option}}
+      {{on "click" (fn this.select option)}}
+      {{on "mouseenter" (fn this.hover option)}}
+    />
   {{/if}}
 {{/each}}

--- a/addon/templates/components/x-select.hbs
+++ b/addon/templates/components/x-select.hbs
@@ -47,7 +47,7 @@
       valueKey=this.valueKey
       freeText=this.freeText
       shouldFilter=this.shouldFilter
-      select=(action "select")
+      onSelect=(action "select")
     }}
   </div>
 {{/if}}


### PR DESCRIPTION
Migrates dropdown components to class syntax.

Part of #74 + fixes.