### PR TITLE
Do not use Evented

### DIFF
--- a/addon/components/select-dropdown.js
+++ b/addon/components/select-dropdown.js
@@ -11,7 +11,7 @@ export default class SelectDropdownComponent extends Component {
 
   didInsertElement() {
     super.didInsertElement(...arguments);
-    this.parent.on('keyPress', this, this.keys);
+    this.updateDropdownKeypressHandler(this.keys.bind(this));
   }
 
   didReceiveAttrs() {
@@ -27,7 +27,7 @@ export default class SelectDropdownComponent extends Component {
 
   willDestroyElement() {
     super.willDestroyElement(...arguments);
-    this.parent.off('keyPress', this, this.keys);
+    this.updateDropdownKeypressHandler();
   }
 
   @computed('list', 'model.[]', 'shouldFilter', 'token', 'values.[]')

--- a/addon/components/x-select.hbs
+++ b/addon/components/x-select.hbs
@@ -40,7 +40,6 @@
 {{#if this.isOpen}}
   <div class="es-options">
     <this.dropdown
-      @parent={{this}}
       @model={{@model}}
       @token={{this.token}}
       @values={{@values}}
@@ -49,6 +48,7 @@
       @freeText={{this.freeText}}
       @shouldFilter={{this.shouldFilter}}
       @onSelect={{this.select}}
+      @updateDropdownKeypressHandler={{this.updateDropdownKeypressHandler}}
     />
   </div>
 {{/if}}

--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -1,14 +1,15 @@
 import Component from '@ember/component';
 import { action, computed, get } from '@ember/object';
 import { and, bool, not, notEmpty, or } from '@ember/object/computed';
-import Evented from '@ember/object/evented';
 import { next } from '@ember/runloop';
 import { isBlank, isPresent } from '@ember/utils';
 import SelectDropdown from './select-dropdown';
 
-export default class SelectComponent extends Component.extend(Evented) {
+export default class SelectComponent extends Component {
   classNames = ['ember-select'];
   classNameBindings = ['isOpen:es-open', 'isFocus:es-focus', 'canSearch::es-select', 'multiple:es-multiple'];
+
+  #handleDropdownKeypress = null;
 
   autofocus = false;
   canSearch = true;
@@ -197,7 +198,7 @@ export default class SelectComponent extends Component.extend(Evented) {
       case 'Tab':
       case 'Enter':
         if (isOpen) {
-          this.trigger('keyPress', event);
+          this.#handleDropdownKeypress?.(event);
         } else if (this.get('freeText')) {
           this.select(this.get('token'), false);
         }
@@ -213,7 +214,7 @@ export default class SelectComponent extends Component.extend(Evented) {
       case 'ArrowUp':
       case 'ArrowDown':
         if (isOpen) {
-          this.trigger('keyPress', event);
+          this.#handleDropdownKeypress?.(event);
         } else {
           this.set('isOpen', true);
         }
@@ -253,6 +254,11 @@ export default class SelectComponent extends Component.extend(Evented) {
     if (!this.get('multiple')) {
       this.get('input').blur();
     }
+  }
+
+  @action
+  updateDropdownKeypressHandler(handler) {
+    this.#handleDropdownKeypress = handler;
   }
 
   // Handle plain arrays and Ember Data relationships


### PR DESCRIPTION
Currently, the parent component (`x-select`) is being leaked (passed down) to the child component (`select-dropdown`).
Since `Evented` is getting deprecated in Ember.js, use a different pattern instead.

Do not leak parent component in the child component.