### PR TITLE
Remove utils from the app re-export list

### DIFF
--- a/ember-select/rollup.config.mjs
+++ b/ember-select/rollup.config.mjs
@@ -25,13 +25,7 @@ export default {
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but
     // not everything in publicEntrypoints necessarily needs to go here.
-    addon.appReexports([
-      'components/**/*.js',
-      'helpers/**/*.js',
-      'modifiers/**/*.js',
-      'services/**/*.js',
-      'utils/**/*.js',
-    ]),
+    addon.appReexports(['components/**/*.js', 'helpers/**/*.js', 'modifiers/**/*.js', 'services/**/*.js']),
 
     // Follow the V2 Addon rules about dependencies. Your code can import from
     // `dependencies` and `peerDependencies` as well as standard Ember-provided


### PR DESCRIPTION
Remove `utils` from the app re-export list, `utils/*` does not have a `default` export.